### PR TITLE
enable version-detector to use random QUIC connection ID

### DIFF
--- a/quic_version_detector/main.py
+++ b/quic_version_detector/main.py
@@ -4,7 +4,7 @@ import asyncio
 from quic_version_detector import quic, net, cli
 
 
-def print_results(host, port ,version_negotation_packet):
+def print_results(host, port, version_negotiation_packet):
     """Prints retrieved results.
 
     Args:
@@ -13,7 +13,7 @@ def print_results(host, port ,version_negotation_packet):
         version_negotation_packet (quic.VersionNegotationPacket)
     """
     print('"{}:{}" supported versions:'.format(host, port))
-    for version in version_negotation_packet.supported_versions:
+    for version in version_negotiation_packet.supported_versions:
         print('    ', version)
 
 class UdpHandler:

--- a/quic_version_detector/quic.py
+++ b/quic_version_detector/quic.py
@@ -17,7 +17,7 @@ class Packet:
     def to_buff(self):
         """
         Returns:
-            str: QUIC packet encoded to ascii string.
+            bytes: QUIC packet encoded as bytes.
         """
         return self.public_flags + \
             self.connection_id + self.version + bytes.fromhex('01')

--- a/quic_version_detector/quic.py
+++ b/quic_version_detector/quic.py
@@ -1,5 +1,7 @@
 """QUIC protocol related facilities."""
 
+import random
+
 
 class Packet:
     """QUIC packet class.
@@ -58,6 +60,7 @@ def dummy_version_packet():
     Returns:
         quic.Packet
     """
+    connection_id = bytes([random.getrandbits(8) for _ in range(8)])
     return Packet(public_flags=bytes.fromhex('0d'),
-                  connection_id=bytes.fromhex('0102030405060708'),
+                  connection_id=connection_id,
                   version=bytes.fromhex('0a0a0a0a'))

--- a/quic_version_detector/quic.py
+++ b/quic_version_detector/quic.py
@@ -17,8 +17,8 @@ class Packet:
         Returns:
             str: QUIC packet encoded to ascii string.
         """
-        packet = self.public_flags + self.connection_id + self.version + '\x01'
-        return packet.encode('ascii')
+        return self.public_flags + \
+            self.connection_id + self.version + bytes.fromhex('01')
 
 
 class VersionNegotationPacket:
@@ -58,5 +58,6 @@ def dummy_version_packet():
     Returns:
         quic.Packet
     """
-    return Packet(public_flags='\x0d',
-        connection_id='\x01\x02\x03\x04\x05\x06\x07\x08', version='Q012')
+    return Packet(public_flags=bytes.fromhex('0d'),
+                  connection_id=bytes.fromhex('0102030405060708'),
+                  version=bytes.fromhex('0a0a0a0a'))


### PR DESCRIPTION
Maybe I interpreted [the RFC](https://quicwg.github.io/base-drafts/draft-ietf-quic-transport.html#rfc.section.5.2) correctly, maybe not. Please let me know your thoughts.

Also, since we are using Python3 it seems better to use `bytes`.

Finally, [per the WG](https://github.com/quicwg/base-drafts/wiki/QUIC-Versions) it is better to use the reserved version negotiation version.